### PR TITLE
Implementación de Centroide mas Cercano con dataset

### DIFF
--- a/proyecto_final/centroide.r
+++ b/proyecto_final/centroide.r
@@ -1,0 +1,53 @@
+install.packages("git2r")
+install.packages("caret")
+install.packages("ISLR")
+library(git2r)
+library(ISLR)
+library(caret)
+# Cargar el dataset Khan
+data(Khan)
+# Separar los conjuntos de entrenamiento y prueba
+xtrain <- Khan$xtrain
+ytrain <- Khan$ytrain
+xtest <- Khan$xtest
+ytest <- Khan$ytest
+
+# Obtener las etiquetas de clase
+clases <- unique(ytrain)
+
+
+# Inicializar una lista para almacenar los centroides
+centroides <- list()
+
+# Calcular los centroides para cada clase
+for (clase in clases) {
+  # Filtrar las instancias de la clase actual
+  instancias_clase <- xtrain[ytrain == clase, ]
+  
+  # Calcular el centroide promediando los valores de los atributos
+  centroide <- colMeans(instancias_clase)
+  print(centroide)
+  # Almacenar el centroide en la lista
+  centroides[[as.character(clase)]] <- centroide
+}
+print(centroides)
+
+distancias <- matrix(NA, nrow = nrow(xtest), ncol = length(clases))
+
+for (i in 1:nrow(xtest)) {
+  for (j in 1:length(clases)) {
+    # Calcular la distancia euclidiana entre la observación y el centroide
+    distancias[i, j] <- sqrt(sum((xtest[i, ] - centroides[[as.character(clases[j])]])^2))
+  }
+}
+
+clases_predichas <- clases[apply(distancias, 1, which.min)]
+
+# Convertir las variables a factores con los mismos niveles
+clases_predichas <- factor(clases_predichas, levels = unique(c(clases_predichas, ytest)))
+ytest <- factor(ytest, levels = unique(c(clases_predichas, ytest)))
+
+# Calcular la matriz de confusión
+confusionMatrix(clases_predichas, ytest)
+cm <- confusionMatrix(clases_predichas, ytest)
+print(cm)


### PR DESCRIPTION
Implementación de Centroide mas Cercano con dataset:

Primero instale las librerias que necesitaba usar, despues usando el dataset Khan del libro ISLR propocionado por el profesor, lo separe en 2 conjuntos (entrenamiento y prueba). 
Luego inicializo una lista centroides que va a contener los 4 centroides calculados para cada una de las clases; esto se realiza en el for, que recorre las 4 clases y calcula un vector centroide que es el promedio de cada una de las variables del dataset, a continuación adjunto una captura con datos que no son reales pero a fines explicativos de funcionamiento sirve.
![image](https://github.com/agussanchez97/ia-uncuyo-2021/assets/82063987/3a7ec978-9e60-4a5a-a6d8-e1f4fc23ab70)
Luego se calculan las distancias que hay desde la observación (datos de prueba) a los centroides y se clasifica a la clase que corresponda según la distancia mas cercana.

Por ultimo se calcula la matriz de confusión y a continuación adjunto las metricas obtenidas del modelo sin ningun ajuste.
![image](https://github.com/agussanchez97/ia-uncuyo-2021/assets/82063987/f77e7c7c-cc60-413d-943a-4443f503bccc)

