### PR TITLE
Tratamiento del dataset

### DIFF
--- a/proyecto_final/centroide.r
+++ b/proyecto_final/centroide.r
@@ -6,11 +6,35 @@ library(ISLR)
 library(caret)
 # Cargar el dataset Khan
 data(Khan)
+
 # Separar los conjuntos de entrenamiento y prueba
 xtrain <- Khan$xtrain
 ytrain <- Khan$ytrain
 xtest <- Khan$xtest
 ytest <- Khan$ytest
+
+#---------------------------Distancia de Mahalanobis-------------------------------------#
+
+  # Calcular la matriz de covarianza del dataset
+  cov_matrix <- cov(t(xtrain))
+  
+  # Calcular la media de cada variable
+  means <- colMeans(t(xtrain))
+  
+  # Calcular la distancia de Mahalanobis para cada observacion
+  mahalanobis_dist <- mahalanobis(t(xtrain), center = means, cov = cov_matrix)
+  
+  # Establecer un umbral para identificar valores atipicos
+  threshold <- qchisq(0.95, df = ncol(xtrain))
+  
+  # Identificar los valores atipicos
+  outliers <- which(mahalanobis_dist > threshold)
+  
+  # Imprimir los Indices de los valores atipicos
+  print(outliers)
+
+#------------------------------------------------------------------------------------------#
+
 
 # Obtener las etiquetas de clase
 clases <- unique(ytrain)

--- a/proyecto_final/centroide.r
+++ b/proyecto_final/centroide.r
@@ -35,6 +35,34 @@ ytest <- Khan$ytest
 
 #------------------------------------------------------------------------------------------#
 
+#-----------------------BUSCAR DESBALANCES-------------------------------------------------#
+  
+# Calcular el conteo de observaciones por clase
+class_counts <- table(ytrain)
+  
+# Mostrar el conteo de observaciones por clase
+print(class_counts)
+  
+# Calcular la proporción de observaciones por clase
+class_proportions <- prop.table(class_counts)
+  
+# Mostrar la proporción de observaciones por clase
+print(class_proportions)
+  
+# Ajustar el tamaño del área de trazado
+pdf("grafico.pdf", width = 10, height = 6)
+  
+# Ajustar los márgenes de la figura
+par(mar = c(5, 5, 4, 2) + 0.1)
+  
+# Graficar las proporciones de observaciones por clase
+barplot(class_proportions, main = "Distribución de Clases en el Dataset Khan", xlab = "Clase", ylab = "Proporción")
+  
+# Cerrar el archivo PDF
+dev.off()
+
+
+#-------------------------------------------------------------------------------------------------
 
 # Obtener las etiquetas de clase
 clases <- unique(ytrain)


### PR DESCRIPTION
> **Buscar valores anómalos o extremos.**

_**Método de Mahalanobis:**_

La distancia de Mahalanobis es una medida de la distancia entre un punto y un conjunto de puntos, teniendo en cuenta la estructura de covarianza de los datos. Esta distancia se utiliza para evaluar la similitud o la discrepancia entre un punto y una distribución multivariada.
Se define como:

D(x) = √((x - μ)' Σ^(-1) (x - μ))

Donde:
x es el punto para el cual se calcula la distancia.
μ es el vector de medias de las variables en el conjunto de datos.
Σ es la matriz de covarianza.

En el codigo se realizó el calculo de la distancia de cada una de las observaciones correspondientes al conjunto de datos y se definio un umbral de 0.95 para identificar los valores anomalos. Para el conjunto de datos Khan, no se identifico ninguno.

> **Desbalance de clases.**
Para determinar si las clases del dataset Khan están desbalanceadas, se analizan las proporciones de observaciones por clase. En este caso, las proporciones son las siguientes:

Clase 1: 0.1269841
Clase 2: 0.3650794
Clase 3: 0.1904762
Clase 4: 0.3174603

Se puede notar que la Clase 2 tiene la proporción más alta (0.3650794), mientras que la Clase 1 tiene la proporción más baja (0.1269841). Esto sugiere cierto desbalance en las clases, que se puede visualizar en la siguien imagen.

![image](https://github.com/agussanchez97/ia-uncuyo-2021/assets/82063987/38da3956-adf3-457c-9a37-53e1ce82a11f)




