### PR TITLE
Implementacion de GLMNET dataset

### DIFF
--- a/proyecto_final/code/glmnet.r
+++ b/proyecto_final/code/glmnet.r
@@ -23,13 +23,20 @@ xtrain <- Khan$xtrain
 ytrain <- Khan$ytrain
 xtest <- Khan$xtest
 ytest <- Khan$ytest
+print(xtrain) # matriz num 63x2308. columna: variable, fila: observación
+print(ytrain) # vector num 63. contiene las etiquetas de clase
+print(xtest) # matriz num 20x2308.
+print(ytest) # vector num 20.
 
-# Entrenar el modelo GLMNET con validación cruzada
+# Contar ocurrencias
+frecuencias <- table(ytrain)
+print(frecuencias)
+
+# Entrenar el modelo GLMNET
 model <- glmnet(xtrain, ytrain, family = "multinomial")
 
 # Realizar predicciones en el conjunto de prueba
 predictions <- predict(model, newx = xtest, type = "class")
-
 
 # Evaluar la precisión del modelo
 accuracy <- mean(predictions == ytest)
@@ -38,6 +45,8 @@ print(accuracy)
 # Convertir las variables a factores con los mismos niveles
 predictions <- factor(predictions, levels = unique(c(predictions, ytest)))
 ytest <- factor(ytest, levels = unique(c(predictions, ytest)))
+print(predictions)
+print(ytest)
 
 # Calcular la matriz de confusión
 confusionMatrix(predictions, ytest)

--- a/proyecto_final/code/glmnet.r
+++ b/proyecto_final/code/glmnet.r
@@ -27,11 +27,8 @@ ytest <- Khan$ytest
 # Entrenar el modelo GLMNET con validación cruzada
 model <- glmnet(xtrain, ytrain, family = "multinomial")
 
-# Obtener el valor óptimo de lambda
-lambda_min <- model$lambda.min
-
 # Realizar predicciones en el conjunto de prueba
-predictions <- predict(model, newx = xtest, s = lambda_min, type = "class")
+predictions <- predict(model, newx = xtest, type = "class")
 
 
 # Evaluar la precisión del modelo
@@ -46,6 +43,3 @@ ytest <- factor(ytest, levels = unique(c(predictions, ytest)))
 confusionMatrix(predictions, ytest)
 cm <- confusionMatrix(predictions, ytest)
 print(cm)
-
-
-

--- a/proyecto_final/code/glmnet.r
+++ b/proyecto_final/code/glmnet.r
@@ -25,13 +25,14 @@ xtest <- Khan$xtest
 ytest <- Khan$ytest
 
 # Entrenar el modelo GLMNET con validación cruzada
-cv_model <- cv.glmnet(xtrain, ytrain, family = "multinomial")
+model <- glmnet(xtrain, ytrain, family = "multinomial")
 
 # Obtener el valor óptimo de lambda
-lambda_min <- cv_model$lambda.min
+lambda_min <- model$lambda.min
 
 # Realizar predicciones en el conjunto de prueba
-predictions <- predict(glmnet_model, newx = xtest, s = lambda_min, type = "class")
+predictions <- predict(model, newx = xtest, s = lambda_min, type = "class")
+
 
 # Evaluar la precisión del modelo
 accuracy <- mean(predictions == ytest)

--- a/proyecto_final/code/glmnet.r
+++ b/proyecto_final/code/glmnet.r
@@ -1,0 +1,50 @@
+# Instalar paquetes
+install.packages("git2r")
+install.packages("stringi")
+install.packages("caret")
+install.packages("ISLR")
+install.packages("glmnet")
+install.packages("MLmetrics")
+install.packages("pROC")
+
+# Cargar paquetes
+library(git2r)
+library(ISLR)
+library(caret)
+library(glmnet)
+library(MLmetrics)
+library(pROC)
+
+# Cargar el dataset Khan
+data(Khan)
+
+# Separar los conjuntos de entrenamiento y prueba
+xtrain <- Khan$xtrain
+ytrain <- Khan$ytrain
+xtest <- Khan$xtest
+ytest <- Khan$ytest
+
+# Entrenar el modelo GLMNET con validación cruzada
+cv_model <- cv.glmnet(xtrain, ytrain, family = "multinomial")
+
+# Obtener el valor óptimo de lambda
+lambda_min <- cv_model$lambda.min
+
+# Realizar predicciones en el conjunto de prueba
+predictions <- predict(glmnet_model, newx = xtest, s = lambda_min, type = "class")
+
+# Evaluar la precisión del modelo
+accuracy <- mean(predictions == ytest)
+print(accuracy)
+
+# Convertir las variables a factores con los mismos niveles
+predictions <- factor(predictions, levels = unique(c(predictions, ytest)))
+ytest <- factor(ytest, levels = unique(c(predictions, ytest)))
+
+# Calcular la matriz de confusión
+confusionMatrix(predictions, ytest)
+cm <- confusionMatrix(predictions, ytest)
+print(cm)
+
+
+


### PR DESCRIPTION
# Implementacion de GLMNET dataset
En el codigo se instalan los paquetes necesarios y luego se cargan. Tambien se carga el conjunto de datos "Khan" el cual se separa en conjuntos de entrenamiento (variables xtrain y ytrain) y de prueba (variables xtest y ytest).
En este caso para los valores de `alpha`, `lambda`, `nlambda` y `standardize`  se utilizan los valores predeterminados en la función glmnet().

Se entrena el modelo GLMNET en el conjunto de entrenamiento y con la familia de distribución "multinomial".  Se realizan las predicciones en el conjunto de prueba.
Accuracy: 0.935

Por ultimo se calcula la matriz de confusión y a continuación adjunto las metricas obtenidas del modelo sin ningun ajuste:
![image](https://github.com/agussanchez97/ia-uncuyo-2021/assets/88351747/c400d052-707d-47b0-8991-4d041214d1f9)

En la matriz de confusión se muestra la relación entre las predicciones del modelo (filas) y las clases reales de los datos (columnas). Cada celda indica la cantidad de instancias que se clasificaron en esa categoría. Por ejemplo, en la primera fila y primera columna, hay 3 instancias que fueron clasificadas correctamente como clase 1. En la segunda fila y tercera columna, hay 1 instancia que fue clasificada incorrectamente como clase 3 en lugar de la clase 4 correcta.


