### PR TITLE
Variacion de standardize 

### DIFF
--- a/proyecto_final/code/glmnet.r
+++ b/proyecto_final/code/glmnet.r
@@ -1,0 +1,45 @@
+# Instalar paquetes
+install.packages("git2r")
+install.packages("stringi")
+install.packages("caret")
+install.packages("ISLR")
+install.packages("glmnet")
+install.packages("MLmetrics")
+install.packages("pROC")
+
+# Cargar paquetes
+library(git2r)
+library(ISLR)
+library(caret)
+library(glmnet)
+library(MLmetrics)
+library(pROC)
+
+# Cargar el dataset Khan
+data(Khan)
+
+# Separar los conjuntos de entrenamiento y prueba
+xtrain <- Khan$xtrain
+ytrain <- Khan$ytrain
+xtest <- Khan$xtest
+ytest <- Khan$ytest
+
+# Entrenar el modelo GLMNET con validación cruzada
+model <- glmnet(xtrain, ytrain, family = "multinomial", standardize = FALSE)
+
+# Realizar predicciones en el conjunto de prueba
+predictions <- predict(model, newx = xtest, type = "class")
+
+
+# Evaluar la precisión del modelo
+accuracy <- mean(predictions == ytest)
+print(accuracy)
+
+# Convertir las variables a factores con los mismos niveles
+predictions <- factor(predictions, levels = unique(c(predictions, ytest)))
+ytest <- factor(ytest, levels = unique(c(predictions, ytest)))
+
+# Calcular la matriz de confusión
+confusionMatrix(predictions, ytest)
+cm <- confusionMatrix(predictions, ytest)
+print(cm)


### PR DESCRIPTION
Probamos si es mejor dejar el parámetro standardize en su valor predeterminado (TRUE) o establecerlo en FALSE.
Los resultados de precicion fueron mas altos en todas las pruebas usando estandarización (standardize = TRUE) con precicion de 0.93, comparados con la aplicacion del modelo sin estandarizacion (standardize = FALSE) que obtuvo precicion de 0.89.
Esto puede ser porque en este caso la estandarización es beneficiosa ya que las variables tienen diferentes escalas y se desea evitar que una variable con valores grandes domine el modelo en comparación con las variables con valores más pequeños. 
